### PR TITLE
Update to add support for Internet Explorer

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -115,7 +115,7 @@
     ],
     "no-confusing-arrow": "error",
     "no-useless-constructor": "error",
-    "no-var": "error",
+    "no-var": "off",
     "prefer-const": "error",
     "prefer-template": "off"
   }

--- a/.eslintrc
+++ b/.eslintrc
@@ -117,6 +117,6 @@
     "no-useless-constructor": "error",
     "no-var": "error",
     "prefer-const": "error",
-    "prefer-template": "error"
+    "prefer-template": "off"
   }
 }

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function throwError(argument, argumentName, typeString) {
     } catch (_) {
         argumentString = argument;
     }
-    throw new TypeError(`Expected ${argumentName || 'argument'} to be ${typeString}. Value received: ${argumentString}`);
+    throw new TypeError('Expected ' + (argumentName || 'argument') + ' to be ' + typeString + '. Value received: ' + argumentString);
 }
 
 module.exports = class ArgumentContracts {
@@ -50,7 +50,7 @@ module.exports = class ArgumentContracts {
     static assertArrayOf(argument, type, argumentName) {
         ArgumentContracts.assertArray(argument, argumentName);
         if (!argument.every(item => isTypeMatch(item, type))) {
-            throwError(argument, argumentName, `an array of ${type}`);
+            throwError(argument, argumentName, 'an array of ' + type);
         }
     }
 
@@ -92,7 +92,7 @@ module.exports = class ArgumentContracts {
 
     static assertType(argument, type, argumentName) {
         if (!isTypeMatch(argument, type)) {
-            throwError(argument, argumentName, `a ${type}`);
+            throwError(argument, argumentName, 'a ' + type);
         }
     }
 };

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function isTypeMatch(argument, type) {
 }
 
 function throwError(argument, argumentName, typeString) {
-    let argumentString;
+    var argumentString;
     try {
         argumentString = JSON.stringify(argument);
     } catch (_) {


### PR DESCRIPTION
This PR replaces template string literals with string concatenation, and replaces the usage of `let` for `var` in order to support usage of this package with Internet Explorer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/terodox/argument-contracts/13)
<!-- Reviewable:end -->
